### PR TITLE
fix: Enable workflows on master/main branches

### DIFF
--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -2,9 +2,9 @@ name: Test and Coverage
 
 on:
   push:
-    branches: [ disabled ]  # Temporarily disabled
+    branches: [ master, main ]
   pull_request:
-    branches: [ disabled ]
+    branches: [ master, main ]
 
 jobs:
   test:

--- a/.github/workflows/unit-tests-coverage.yml
+++ b/.github/workflows/unit-tests-coverage.yml
@@ -2,7 +2,7 @@ name: Unit Tests and Coverage
 
 on:
   push:
-    branches: [ master, main, codecov ]
+    branches: [ master, main ]
   pull_request:
     branches: [ master, main ]
 


### PR DESCRIPTION
## Исправление GitHub Actions workflows

После успешного мержа Codecov интеграции, нужно:

1. **Включить обратно основной workflow** `test-and-coverage.yml`
   - Убраны ветки 'disabled' 
   - Теперь будет запускаться на master/main

2. **Убрать временную ветку из триггеров** в `unit-tests-coverage.yml`
   - Убрана ветка 'codecov' из триггеров
   - Оставлены только master и main

Оба workflow теперь готовы к production использованию.